### PR TITLE
Create new dataLoaders per request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.sublime-project
 *.sublime-workspace
 .idea/
+.vscode/
 
 lib-cov
 *.seed

--- a/src/app.js
+++ b/src/app.js
@@ -4,28 +4,36 @@ import 'isomorphic-fetch';
 
 import Koa from 'koa';
 import cors from 'koa-cors';
-import graphqlHTTP from 'koa-graphql';
+import graphqlHttp from 'koa-graphql';
 import convert from 'koa-convert';
 import logger from 'koa-logger';
 
 import { schema } from './schema';
 import { jwtSecret } from './config';
 import { getUser } from './auth';
+import * as dataLoaders from './loader';
 
 const app = new Koa();
 
 app.keys = jwtSecret;
 
-app.use(logger());
-app.use(convert(cors()));
-app.use(convert(graphqlHTTP(async (req) => {
+const graphqlSettingsPerReq = async (req) => {
+
   const { user } = await getUser(req.header.authorization);
+
+  const generatedDataLoaders = {};
+
+  Object.keys(dataLoaders).forEach(item => {
+    generatedDataLoaders[item] = dataLoaders[item].getLoader()
+  });
 
   return {
     graphiql: process.env.NODE_ENV !== 'production',
     schema,
     context: {
       user,
+      req,
+      dataLoaders : generatedDataLoaders,
     },
     formatError: (error) => {
       console.log(error.message);
@@ -39,6 +47,12 @@ app.use(convert(graphqlHTTP(async (req) => {
       };
     },
   };
-})));
+};
+
+const graphqlServer = convert(graphqlHttp(graphqlSettingsPerReq));
+
+app.use(logger());
+app.use(convert(cors()));
+app.use(graphqlServer);
 
 export default app;

--- a/src/app.js
+++ b/src/app.js
@@ -11,7 +11,7 @@ import logger from 'koa-logger';
 import { schema } from './schema';
 import { jwtSecret } from './config';
 import { getUser } from './auth';
-import * as dataLoaders from './loader';
+import * as loaders from './loader';
 
 const app = new Koa();
 
@@ -21,11 +21,10 @@ const graphqlSettingsPerReq = async (req) => {
 
   const { user } = await getUser(req.header.authorization);
 
-  const generatedDataLoaders = {};
-
-  Object.keys(dataLoaders).forEach(item => {
-    generatedDataLoaders[item] = dataLoaders[item].getLoader()
-  });
+  const dataloaders = Object.keys(loaders).reduce((dataloaders, loaderKey) => ({
+    ...dataloaders,
+    [loaderKey]: loaders[loaderKey].getLoader(),
+  }), {});
 
   return {
     graphiql: process.env.NODE_ENV !== 'production',
@@ -33,7 +32,7 @@ const graphqlSettingsPerReq = async (req) => {
     context: {
       user,
       req,
-      dataLoaders : generatedDataLoaders,
+      dataloaders,
     },
     formatError: (error) => {
       console.log(error.message);

--- a/src/connection/ConnectionFromMongoCursor.js
+++ b/src/connection/ConnectionFromMongoCursor.js
@@ -39,7 +39,7 @@ export default class ConnectionFromMongoCursor {
    * object for use in GraphQL. It uses array offsets as pagination, so pagiantion
    * will work only if the data set is satic.
    */
-  static async connectionFromMongoCursor(viewer, inMongoCursor, args = {}, loader) {
+  static async connectionFromMongoCursor(ctx, inMongoCursor, args = {}, loader) {
     const mongodbCursor = inMongoCursor;
     const { after, before } = args;
     let { first, last } = args;
@@ -82,7 +82,7 @@ export default class ConnectionFromMongoCursor {
 
     const edges = slice.map((value, index) => ({
       cursor: ConnectionFromMongoCursor.offsetToCursor(startOffset + index),
-      node: loader(viewer, value._id),
+      node: loader(ctx, value._id),
     }));
 
     const firstEdge = edges[0];

--- a/src/connection/ConnectionFromMongoCursor.js
+++ b/src/connection/ConnectionFromMongoCursor.js
@@ -39,7 +39,7 @@ export default class ConnectionFromMongoCursor {
    * object for use in GraphQL. It uses array offsets as pagination, so pagiantion
    * will work only if the data set is satic.
    */
-  static async connectionFromMongoCursor(ctx, inMongoCursor, args = {}, loader) {
+  static async connectionFromMongoCursor(context, inMongoCursor, args = {}, loader) {
     const mongodbCursor = inMongoCursor;
     const { after, before } = args;
     let { first, last } = args;
@@ -82,7 +82,7 @@ export default class ConnectionFromMongoCursor {
 
     const edges = slice.map((value, index) => ({
       cursor: ConnectionFromMongoCursor.offsetToCursor(startOffset + index),
-      node: loader(ctx, value._id),
+      node: loader(context, value._id),
     }));
 
     const firstEdge = edges[0];

--- a/src/interface/NodeInterface.js
+++ b/src/interface/NodeInterface.js
@@ -2,10 +2,9 @@
 
 import { nodeDefinitions, fromGlobalId } from 'graphql-relay';
 
-import ViewerLoader from '../loader/ViewerLoader';
-import ViewerType from '../type/ViewerType';
+import { UserLoader, ViewerLoader } from '../loader';
 
-import UserLoader from '../loader/UserLoader';
+import ViewerType from '../type/ViewerType';
 import UserType from '../type/UserType';
 
 const {
@@ -13,12 +12,12 @@ const {
   nodeInterface,
 } = nodeDefinitions(
   // A method that maps from a global id to an object
-  async (globalId, { user }) => {
+  async (globalId, ctx) => {
     const { id, type } = fromGlobalId(globalId);
 
     // console.log('id, type: ', type, id, globalId);
     if (type === 'User') {
-      return await UserLoader.load(user, id);
+      return await UserLoader.load(ctx, id);
     }
     if (type === 'Viewer') {
       return await ViewerLoader.load(id);

--- a/src/interface/NodeInterface.js
+++ b/src/interface/NodeInterface.js
@@ -12,12 +12,12 @@ const {
   nodeInterface,
 } = nodeDefinitions(
   // A method that maps from a global id to an object
-  async (globalId, ctx) => {
+  async (globalId, context) => {
     const { id, type } = fromGlobalId(globalId);
 
     // console.log('id, type: ', type, id, globalId);
     if (type === 'User') {
-      return await UserLoader.load(ctx, id);
+      return await UserLoader.load(context, id);
     }
     if (type === 'Viewer') {
       return await ViewerLoader.load(id);

--- a/src/interface/__tests__/NodeInterface.spec.js
+++ b/src/interface/__tests__/NodeInterface.spec.js
@@ -4,7 +4,10 @@ import { schema } from '../../schema';
 import {
   User,
 } from '../../model';
-import { setupTest } from '../../../test/helper';
+import {
+  getContext,
+  setupTest,
+} from '../../../test/helper';
 
 beforeEach(async () => await setupTest());
 
@@ -29,7 +32,7 @@ it('should load Viewer', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext(user);
 
   const result = await graphql(schema, query, rootValue, context);
   const { node } = result.data;
@@ -56,7 +59,7 @@ it('should load User', async () => {
   `;
 
   const rootValue = {};
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
   const { node } = result.data;

--- a/src/loader/UserLoader.js
+++ b/src/loader/UserLoader.js
@@ -39,26 +39,26 @@ export default class User {
     return true;
   }
 
-  static async load({ user: viewer, dataLoaders }, id) {
+  static async load({ user: viewer, dataloaders }, id) {
     if (!id) return null;
 
-    const data = await dataLoaders.UserLoader.load(id);
+    const data = await dataloaders.UserLoader.load(id);
 
     if (!data) return null;
 
     return User.viewerCanSee(viewer, data) ? new User(data, viewer) : null;
   }
 
-  static clearCache({ dataLoaders }, id) {
-    return dataLoaders.UserLoader.clear(id.toString());
+  static clearCache({ dataloaders }, id) {
+    return dataloaders.UserLoader.clear(id.toString());
   }
 
-  static async loadUsers(ctx, args) {
+  static async loadUsers(context, args) {
     const where = args.search ? { name: { $regex: new RegExp(`^${args.search}`, 'ig') } } : {};
     const users = UserModel
       .find(where, { _id: 1 })
       .sort({ createdAt: -1 });
 
-    return ConnectionFromMongoCursor.connectionFromMongoCursor(ctx, users, args, User.load);
+    return ConnectionFromMongoCursor.connectionFromMongoCursor(context, users, args, User.load);
   }
 }

--- a/src/loader/UserLoader.js
+++ b/src/loader/UserLoader.js
@@ -18,10 +18,6 @@ export default class User {
   email: string;
   active: boolean;
 
-  static userLoader = new DataLoader(
-    ids => Promise.all(ids.map(id => UserModel.findOne({ _id: id }))),
-  );
-
   constructor(data: UserType, viewer) {
     this.id = data.id;
     this._id = data._id;
@@ -34,31 +30,35 @@ export default class User {
     }
   }
 
+  static getLoader = () => new DataLoader(
+    ids => Promise.all(ids.map(id => UserModel.findOne({ _id: id })))
+  );
+
   static viewerCanSee(viewer, data) {
     // Anyone can se another user
     return true;
   }
 
-  static async load(viewer, id) {
+  static async load({ user: viewer, dataLoaders }, id) {
     if (!id) return null;
 
-    const data = await User.userLoader.load(id);
+    const data = await dataLoaders.UserLoader.load(id);
 
     if (!data) return null;
 
     return User.viewerCanSee(viewer, data) ? new User(data, viewer) : null;
   }
 
-  static clearCache(id) {
-    return User.userLoader.clear(id.toString());
+  static clearCache({ dataLoaders }, id) {
+    return dataLoaders.UserLoader.clear(id.toString());
   }
 
-  static async loadUsers(viewer, args) {
+  static async loadUsers(ctx, args) {
     const where = args.search ? { name: { $regex: new RegExp(`^${args.search}`, 'ig') } } : {};
     const users = UserModel
       .find(where, { _id: 1 })
       .sort({ createdAt: -1 });
 
-    return ConnectionFromMongoCursor.connectionFromMongoCursor(viewer, users, args, User.load);
+    return ConnectionFromMongoCursor.connectionFromMongoCursor(ctx, users, args, User.load);
   }
 }

--- a/src/loader/ViewerLoader.js
+++ b/src/loader/ViewerLoader.js
@@ -18,4 +18,7 @@ export default class Viewer {
 
     return new Viewer(data);
   }
+
+  // There is no need for a DataLoader instance here.
+  static getLoader = () => Viewer;
 }

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -1,0 +1,2 @@
+export UserLoader from './UserLoader'
+export ViewerLoader from './ViewerLoader'

--- a/src/mutation/ChangePasswordMutation.js
+++ b/src/mutation/ChangePasswordMutation.js
@@ -7,7 +7,7 @@ import {
 } from 'graphql-relay';
 
 import UserType from '../type/UserType';
-import UserLoader from '../loader/UserLoader';
+import { UserLoader } from '../loader';
 
 export default mutationWithClientMutationId({
   name: 'ChangePassword',
@@ -47,7 +47,7 @@ export default mutationWithClientMutationId({
     },
     me: {
       type: UserType,
-      resolve: (obj, args, { user }) => UserLoader.load(user, user.id),
+      resolve: (obj, args, ctx) => UserLoader.load(ctx, user.id),
     },
   },
 });

--- a/src/mutation/ChangePasswordMutation.js
+++ b/src/mutation/ChangePasswordMutation.js
@@ -47,7 +47,7 @@ export default mutationWithClientMutationId({
     },
     me: {
       type: UserType,
-      resolve: (obj, args, ctx) => UserLoader.load(ctx, user.id),
+      resolve: (obj, args, context) => UserLoader.load(context, user.id),
     },
   },
 });

--- a/src/mutation/__tests__/ChangePasswordMutation.spec.js
+++ b/src/mutation/__tests__/ChangePasswordMutation.spec.js
@@ -4,7 +4,10 @@ import {
   User,
 } from '../../model';
 import { generateToken } from '../../auth';
-import { setupTest } from '../../../test/helper';
+import {
+  getContext,
+  setupTest,
+} from '../../../test/helper';
 
 beforeEach(async () => await setupTest());
 
@@ -23,7 +26,7 @@ it('should not change password of non authorized user', async () => {
   `;
 
   const rootValue = {};
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
   const { errors } = result;
@@ -54,7 +57,7 @@ it('should not change password if oldPassword is invalid', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext(user);
 
   const result = await graphql(schema, query, rootValue, context);
   const { ChangePassword } = result.data;
@@ -86,7 +89,7 @@ it('should change password if oldPassword is correct', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext(user);
 
   const result = await graphql(schema, query, rootValue, context);
   const { ChangePassword } = result.data;

--- a/src/mutation/__tests__/LoginEmailMutation.spec.js
+++ b/src/mutation/__tests__/LoginEmailMutation.spec.js
@@ -4,7 +4,10 @@ import {
   User,
 } from '../../model';
 import { generateToken } from '../../auth';
-import { setupTest } from '../../../test/helper';
+import {
+  getContext,
+  setupTest,
+} from '../../../test/helper';
 
 beforeEach(async () => await setupTest());
 
@@ -24,7 +27,7 @@ it('should not login if email is not in the database', async () => {
   `;
 
   const rootValue = {};
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
   const { LoginEmail } = result.data;
@@ -57,7 +60,7 @@ it('should not login with wrong email', async () => {
   `;
 
   const rootValue = {};
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
   const { LoginEmail } = result.data;
@@ -92,7 +95,7 @@ it('should generate token when email and password is correct', async () => {
   `;
 
   const rootValue = {};
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
   const { LoginEmail } = result.data;

--- a/src/mutation/__tests__/RegisterEmailMutation.spec.js
+++ b/src/mutation/__tests__/RegisterEmailMutation.spec.js
@@ -4,7 +4,10 @@ import {
   User,
 } from '../../model';
 import { generateToken } from '../../auth';
-import { setupTest } from '../../../test/helper';
+import {
+  getContext,
+  setupTest,
+} from '../../../test/helper';
 
 beforeEach(async () => await setupTest());
 
@@ -35,7 +38,7 @@ it('should not register with the an existing email', async () => {
   `;
 
   const rootValue = {};
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
   const { RegisterEmail } = result.data;
@@ -63,7 +66,7 @@ it('should create a new user with parameters are valid', async () => {
   `;
 
   const rootValue = {};
-  const context = {};
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
   const { RegisterEmail } = result.data;

--- a/src/type/QueryType.js
+++ b/src/type/QueryType.js
@@ -3,7 +3,7 @@
 import { GraphQLObjectType } from 'graphql';
 import { NodeField } from '../interface/NodeInterface';
 
-import ViewerLoader from '../loader/ViewerLoader';
+import { ViewerLoader } from '../loader';
 import ViewerType from './ViewerType';
 
 export default new GraphQLObjectType({

--- a/src/type/ViewerType.js
+++ b/src/type/ViewerType.js
@@ -24,7 +24,7 @@ export default new GraphQLObjectType({
     id: globalIdField('Viewer'),
     me: {
       type: UserType,
-      resolve: (root, args, ctx) => UserLoader.load(ctx, ctx.user._id),
+      resolve: (root, args, context) => UserLoader.load(context, context.user._id),
     },
     user: {
       type: UserType,
@@ -33,9 +33,9 @@ export default new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLID),
         },
       },
-      resolve: (obj, args, ctx) => {
+      resolve: (obj, args, context) => {
         const { id } = fromGlobalId(args.id);
-        return UserLoader.load(ctx, id);
+        return UserLoader.load(context, id);
       },
     },
     users: {
@@ -46,7 +46,7 @@ export default new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (obj, args, ctx) => UserLoader.loadUsers(ctx, args),
+      resolve: (obj, args, context) => UserLoader.loadUsers(context, args),
     },
   }),
   interfaces: () => [NodeInterface],

--- a/src/type/ViewerType.js
+++ b/src/type/ViewerType.js
@@ -14,7 +14,7 @@ import {
 import { NodeInterface } from '../interface/NodeInterface';
 
 import UserType from './UserType';
-import UserLoader from '../loader/UserLoader';
+import { UserLoader } from '../loader';
 import UserConnection from '../connection/UserConnection';
 
 export default new GraphQLObjectType({
@@ -24,7 +24,7 @@ export default new GraphQLObjectType({
     id: globalIdField('Viewer'),
     me: {
       type: UserType,
-      resolve: (root, args, { user }) => UserLoader.load(user, user._id),
+      resolve: (root, args, ctx) => UserLoader.load(ctx, ctx.user._id),
     },
     user: {
       type: UserType,
@@ -33,9 +33,9 @@ export default new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLID),
         },
       },
-      resolve: (obj, args, { user }) => {
+      resolve: (obj, args, ctx) => {
         const { id } = fromGlobalId(args.id);
-        return UserLoader.load(user, id);
+        return UserLoader.load(ctx, id);
       },
     },
     users: {
@@ -46,7 +46,7 @@ export default new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (obj, args, { user }) => UserLoader.loadUsers(user, args),
+      resolve: (obj, args, ctx) => UserLoader.loadUsers(ctx, args),
     },
   }),
   interfaces: () => [NodeInterface],

--- a/src/type/__tests__/UserType.spec.js
+++ b/src/type/__tests__/UserType.spec.js
@@ -3,7 +3,10 @@ import { schema } from '../../schema';
 import {
   User,
 } from '../../model';
-import { setupTest } from '../../../test/helper';
+import {
+  getContext,
+  setupTest,
+} from '../../../test/helper';
 
 beforeEach(async () => await setupTest());
 
@@ -40,7 +43,7 @@ it('should not show email of other users', async () => {
   `;
 
   const rootValue = {};
-  const context = { user };
+  const context = getContext(user);
 
   const result = await graphql(schema, query, rootValue, context);
   const { edges } = result.data.viewer.users;

--- a/src/type/__tests__/ViewerType.spec.js
+++ b/src/type/__tests__/ViewerType.spec.js
@@ -4,7 +4,10 @@ import { schema } from '../../schema';
 import {
   User,
 } from '../../model';
-import { setupTest } from '../../../test/helper';
+import {
+  getContext,
+  setupTest,
+} from '../../../test/helper';
 
 beforeEach(async () => await setupTest());
 
@@ -30,7 +33,7 @@ it('should get user by id', async () => {
   `;
 
   const rootValue = {};
-  const context = { };
+  const context = getContext();
 
   const result = await graphql(schema, query, rootValue, context);
   const { viewer } = result.data;

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,8 @@
 // @flow
 import mongoose from 'mongoose';
 
+import * as dataLoaders from '../src/loader'
+
 const { ObjectId } = mongoose.Types;
 
 process.env.NODE_ENV = 'test';
@@ -57,6 +59,20 @@ function clearDatabase() {
 
     resolve();
   });
+}
+
+export function getContext(user) {
+  const generatedDataLoaders = {};
+
+  Object.keys(dataLoaders).forEach(item => {
+    generatedDataLoaders[item] = dataLoaders[item].getLoader()
+  });
+
+  return {
+    user,
+    req: {},
+    dataLoaders: generatedDataLoaders,
+  };
 }
 
 export async function setupTest() {

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,7 +1,7 @@
 // @flow
 import mongoose from 'mongoose';
 
-import * as dataLoaders from '../src/loader'
+import * as loaders from '../src/loader';
 
 const { ObjectId } = mongoose.Types;
 
@@ -62,16 +62,15 @@ function clearDatabase() {
 }
 
 export function getContext(user) {
-  const generatedDataLoaders = {};
-
-  Object.keys(dataLoaders).forEach(item => {
-    generatedDataLoaders[item] = dataLoaders[item].getLoader()
-  });
+  const dataloaders = Object.keys(loaders).reduce((dataloaders, loaderKey) => ({
+    ...dataloaders,
+    [loaderKey]: loaders[loaderKey].getLoader(),
+  }), {});
 
   return {
     user,
     req: {},
-    dataLoaders: generatedDataLoaders,
+    dataloaders,
   };
 }
 


### PR DESCRIPTION
This PR creates breaking changes.

Basically all loaders must implement a static method called ``getLoader``, which returns a new ``DataLoader`` instance. This method is called for all loaders, for every request.

Also, they need to be exported from ``src/loaders/index.js``.

Fixes #11 