### PR TITLE
fix ConnectionFromMongooseCursor

### DIFF
--- a/src/connection/ConnectionFromMongoCursor.js
+++ b/src/connection/ConnectionFromMongoCursor.js
@@ -20,7 +20,7 @@ export default class ConnectionFromMongoCursor {
    * be the default.
    */
   static getOffsetWithDefault(cursor, defaultOffset) {
-    if (cursor === undefined) {
+    if (cursor === undefined || cursor === null) {
       return defaultOffset;
     }
     const offset = ConnectionFromMongoCursor.cursorToOffset(cursor);


### PR DESCRIPTION
this commit accepts null cursors on after and before of connections

this fixes an issue with static queries of relay modern

fix facebook/relay#1666