### PR TITLE
Create index.js file for Types

### DIFF
--- a/src/connection/UserConnection.js
+++ b/src/connection/UserConnection.js
@@ -8,7 +8,7 @@ import {
   connectionDefinitions,
 } from 'graphql-relay';
 
-import UserType from '../type/UserType';
+import { UserType } from '../type';
 
 export default connectionDefinitions({
   name: 'User',

--- a/src/interface/NodeInterface.js
+++ b/src/interface/NodeInterface.js
@@ -3,9 +3,7 @@
 import { nodeDefinitions, fromGlobalId } from 'graphql-relay';
 
 import { UserLoader, ViewerLoader } from '../loader';
-
-import ViewerType from '../type/ViewerType';
-import UserType from '../type/UserType';
+import { UserType, ViewerType } from '../type';
 
 const {
   nodeField,

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -1,2 +1,2 @@
-export UserLoader from './UserLoader'
-export ViewerLoader from './ViewerLoader'
+export { default as UserLoader } from './UserLoader';
+export { default as ViewerLoader } from './ViewerLoader';

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -1,1 +1,1 @@
-export User from './User';
+export { default as User } from './User';

--- a/src/mutation/ChangePasswordMutation.js
+++ b/src/mutation/ChangePasswordMutation.js
@@ -6,7 +6,7 @@ import {
   mutationWithClientMutationId,
 } from 'graphql-relay';
 
-import UserType from '../type/UserType';
+import { UserType } from '../type';
 import { UserLoader } from '../loader';
 
 export default mutationWithClientMutationId({

--- a/src/type/QueryType.js
+++ b/src/type/QueryType.js
@@ -4,7 +4,7 @@ import { GraphQLObjectType } from 'graphql';
 import { NodeField } from '../interface/NodeInterface';
 
 import { ViewerLoader } from '../loader';
-import ViewerType from './ViewerType';
+import { ViewerType } from './';
 
 export default new GraphQLObjectType({
   name: 'Query',

--- a/src/type/ViewerType.js
+++ b/src/type/ViewerType.js
@@ -13,7 +13,7 @@ import {
 } from 'graphql-relay';
 import { NodeInterface } from '../interface/NodeInterface';
 
-import UserType from './UserType';
+import { UserType } from './';
 import { UserLoader } from '../loader';
 import UserConnection from '../connection/UserConnection';
 

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -1,0 +1,5 @@
+// QueryType and MutationType are not included here because they would create a circular dependency
+// In a real es6 env a temporal deadzone error would be thrown,
+//   but babel only ignores it and make some modules undefined.
+export { default as UserType } from './UserType';
+export { default as ViewerType } from './ViewerType';


### PR DESCRIPTION
Also changed exports on existing index.js files from `export v from "mod"` to `export { default as v } from "mod"`, since the first one is not in the spec yet, but just a proposal.

https://tc39.github.io/ecma262/#table-42
https://github.com/leebyron/ecmascript-export-default-from