### PR TITLE
fix mongoose deprecation warnings

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -11,6 +11,12 @@ export function connectDatabase() {
       .on('close', () => console.log('Database connection closed.'))
       .once('open', () => resolve(mongoose.connections[0]));
 
-    mongoose.connect(databaseConfig);
+    mongoose.connect(
+      databaseConfig,
+      {
+        useNewUrlParser: true,
+        useCreateIndex: true,
+      },
+    );
   });
 }


### PR DESCRIPTION
Fix mongoose deprecation warnings launched while connecting to MongoDB:

* DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect;
* DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.

Run `npm stat` to reproduce.
A full explanation of these warnings can be found [here.](https://mongoosejs.com/docs/deprecations.html)